### PR TITLE
allow Let's Encrypt conf updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,4 @@ FROM golang:1.6.3
 
 COPY ./lekube /go/bin/
 
-CMD ["lekube", "-conf", "/etc/lekube/lekube.json", "-prod"]
+CMD ["lekube", "-conf", "/etc/lekube/lekube.json"]


### PR DESCRIPTION
Move the config for using production or staging Let's Encrypt API into the config file and allow it and the email to change without restarting the process.

Adds the `use_prod` config that is required to be set. If set to true, the production Let's Encrypt API will be used and correctly validating certs will be created but the rate limits are much more strict. If set to false, the staging API will be used for its higher rate limits and certs will be created that will not validate correctly.

It's recommended to use the `false` setting is used until you're sure your configuration of lekube (and its attendant `LoadBalancer` service or ingress as well as the redirects from your domains to it) are correct. The higher rate limits of the staging Let's Encrypt API are much more forgiving of configuration bugs causing re-attempts.