### PR TITLE
correct docker push build

### DIFF
--- a/travis_docker_push.sh
+++ b/travis_docker_push.sh
@@ -12,7 +12,7 @@ fi
 if [[ ("${TRAVIS_BRANCH}" == "master" && "${TRAVIS_PULL_REQUEST}" == "false")|| "${TRAVIS_BRANCH}" =~ ^test_docker_push.* ]]; then
   echo "setting up push to docker"
 else
-  echo "not on pushable or deployable branch, so no docker work needed"
+  echo "not on pushable branch, so no docker work needed"
   exit
 fi
 

--- a/travis_docker_push.sh
+++ b/travis_docker_push.sh
@@ -9,7 +9,7 @@ if [ -z "${TRAVIS_BRANCH}" ]; then
   die "not running in travis"
 fi
 
-if [[ "${TRAVIS_BRANCH}" == "master" || "${TRAVIS_BRANCH}" =~ ^test_docker_push.* ]]; then
+if [[ ("${TRAVIS_BRANCH}" == "master" && "${TRAVIS_PULL_REQUEST}" == "false")|| "${TRAVIS_BRANCH}" =~ ^test_docker_push.* ]]; then
   echo "setting up push to docker"
 else
   echo "not on pushable or deployable branch, so no docker work needed"

--- a/travis_docker_push.sh
+++ b/travis_docker_push.sh
@@ -25,8 +25,7 @@ docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS || die "unable to 
 # unless running on a test_docker_push branch
 DEPLOY_IMAGE="$REPO:${TRAVIS_BUILD_NUMBER}-${TRAVIS_BRANCH}-${SHA}"
 
-docker build -f Dockerfile -t $REPO .
-docker tag $REPO:$COMMIT ${DEPLOY_IMAGE} || die "unable to tag as ${DEPLOY_IMAGE}"
+docker build -f Dockerfile -t ${DEPLOY_IMAGE} . || die "unable to build as ${DEPLOY_IMAGE}"
 
 echo "Pushing image to docker hub: ${DEPLOY_IMAGE}"
 docker push $REPO || die "unable to push docker tags"

--- a/travis_docker_push.sh
+++ b/travis_docker_push.sh
@@ -26,7 +26,7 @@ docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS || die "unable to 
 DEPLOY_IMAGE="$REPO:${TRAVIS_BUILD_NUMBER}-${TRAVIS_BRANCH}-${SHA}"
 
 docker build -f Dockerfile -t $REPO .
-docker tag -f $REPO:$COMMIT ${DEPLOY_IMAGE} || die "unable to tag as ${DEPLOY_IMAGE}"
+docker tag $REPO:$COMMIT ${DEPLOY_IMAGE} || die "unable to tag as ${DEPLOY_IMAGE}"
 
 echo "Pushing image to docker hub: ${DEPLOY_IMAGE}"
 docker push $REPO || die "unable to push docker tags"


### PR DESCRIPTION
Removes the use of `-f` on `docker tag` that no longer exists. Then goes further by removing the `tag` calls altogether.

Finally, make sure that we do not push in pull requests (their TRAVIS_BRANCH is always set to master).