### PR TITLE
expose expvar and other debug paths but default to be local-only

### DIFF
--- a/config.go
+++ b/config.go
@@ -97,9 +97,10 @@ func (cl *confLoader) load() error {
 }
 
 type allConf struct {
-	Email   string        `json:"email"`
-	UseProd *bool         `json:"use_prod"`
-	Secrets []*secretConf `json:"secrets"`
+	Email          string        `json:"email"`
+	UseProd        *bool         `json:"use_prod"`
+	LocalDebugOnly bool          `json:"local_debug_only"`
+	Secrets        []*secretConf `json:"secrets"`
 }
 
 type secretConf struct {

--- a/config.go
+++ b/config.go
@@ -97,10 +97,10 @@ func (cl *confLoader) load() error {
 }
 
 type allConf struct {
-	Email          string        `json:"email"`
-	UseProd        *bool         `json:"use_prod"`
-	LocalDebugOnly bool          `json:"local_debug_only"`
-	Secrets        []*secretConf `json:"secrets"`
+	Email            string        `json:"email"`
+	UseProd          *bool         `json:"use_prod"`
+	AllowRemoteDebug bool          `json:"allow_remote_debug"`
+	Secrets          []*secretConf `json:"secrets"`
 }
 
 type secretConf struct {

--- a/lekube_test.go
+++ b/lekube_test.go
@@ -19,8 +19,8 @@ func TestConfigLoadGoldenPath(t *testing.T) {
 	if !*c.UseProd {
 		t.Errorf("use_prod: want %t, got %t", true, *c.UseProd)
 	}
-	if !c.LocalDebugOnly {
-		t.Errorf("local_debug_only: want %t, got %t", true, c.LocalDebugOnly)
+	if !c.AllowRemoteDebug {
+		t.Errorf("allow_remote_debug: want %t, got %t", true, c.AllowRemoteDebug)
 	}
 	defaultNS := "default"
 	stagingNS := "staging"

--- a/lekube_test.go
+++ b/lekube_test.go
@@ -18,6 +18,9 @@ func TestConfigLoadGoldenPath(t *testing.T) {
 	if !*c.UseProd {
 		t.Errorf("use_prod: want %t, got %t", true, *c.UseProd)
 	}
+	if !c.LocalDebugOnly {
+		t.Errorf("local_debug_only: want %t, got %t", true, c.LocalDebugOnly)
+	}
 	defaultNS := "default"
 	stagingNS := "staging"
 	emptyNS := ""

--- a/lekube_test.go
+++ b/lekube_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"net/http/httptest"
 	"reflect"
 	"testing"
 )
@@ -54,6 +55,34 @@ func TestConfigLoadGoldenPath(t *testing.T) {
 	for i, sec := range secs {
 		if !reflect.DeepEqual(sec, c.Secrets[i]) {
 			t.Errorf("secret %d: want %#v, got %#v", i, sec, c.Secrets[i])
+		}
+	}
+}
+
+func TestBlockedRequest(t *testing.T) {
+	type testcase struct {
+		path       string
+		remoteAddr string
+		blocked    bool
+	}
+	tests := []testcase{
+		{"/debug", "93.184.216.34", true},
+		{"/debug/", "93.184.216.34", true},
+		{"/debug/foobar", "93.184.216.34", true},
+		{"/", "93.184.216.34", false},
+		{"/foobar", "93.184.216.34", false},
+		{"/debug", "127.0.0.1", false},
+		{"/debug/", "127.0.0.1", false},
+		{"/debug/foobar", "127.0.0.1", false},
+		{"/", "127.0.0.1", false},
+		{"/foobar", "127.0.0.1", false},
+	}
+	for _, tc := range tests {
+		r := httptest.NewRequest("GET", tc.path, nil)
+		r.RemoteAddr = tc.remoteAddr + ":1111"
+		actual := isBlockedRequest(r)
+		if actual != tc.blocked {
+			t.Errorf("path %s, remote addr %s: want %t, got %t", tc.path, r.RemoteAddr, tc.blocked, actual)
 		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -97,9 +97,15 @@ func main() {
 		log.Fatalf("unable to make an account with %s using email %s: %s", dirURLFromConf(conf), conf.Email, err)
 	}
 
+	http.Handle("/", responder)
+	var h http.Handler
+	if conf.LocalDebugOnly {
+		h = responder
+	}
+
 	ch := make(chan error)
 	go func() {
-		ch <- http.ListenAndServe(*httpAddr, responder)
+		ch <- http.ListenAndServe(*httpAddr, h)
 	}()
 
 	go func() {

--- a/main.go
+++ b/main.go
@@ -99,17 +99,14 @@ func main() {
 		log.Fatalf("unable to make an account with %s using email %s: %s", dirURLFromConf(conf), conf.Email, err)
 	}
 
-	if conf.LocalDebugOnly {
-		http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-			if isBlockedRequest(r) {
-				http.NotFound(w, r)
-				return
-			}
-			responder.ServeHTTP(w, r)
-		})
-	} else {
-		http.Handle("/", responder)
-	}
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		conf := cLoader.Get()
+		if !conf.AllowRemoteDebug && isBlockedRequest(r) {
+			http.NotFound(w, r)
+			return
+		}
+		responder.ServeHTTP(w, r)
+	})
 
 	ch := make(chan error)
 	go func() {

--- a/testdata/test.json
+++ b/testdata/test.json
@@ -1,6 +1,7 @@
 {
   "email": "fake@example.com",
   "use_prod": true,
+  "local_debug_only": true,
   "secrets": [
     {
       "namespace": "default",

--- a/testdata/test.json
+++ b/testdata/test.json
@@ -1,7 +1,7 @@
 {
   "email": "fake@example.com",
   "use_prod": true,
-  "local_debug_only": true,
+  "allow_remote_debug": true,
   "secrets": [
     {
       "namespace": "default",


### PR DESCRIPTION
This exposes the expvar and other debug paths in the HTTP server, but, by default, requires requests to them to be local to the machine lekube is running on.