### PR TITLE
add metrics for config load times and build SHA handler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ install:
   - go test -i .
 
 script:
-  - go test . && GOOS=linux GOARCH=amd64 go build . && ./travis_docker_push.sh
+  - go test . && GOOS=linux GOARCH=amd64 go build -ldflags \"-X main.buildSHA=${SHA}\" . && ./travis_docker_push.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ install:
   - go test -i .
 
 script:
-  - go test . && GOOS=linux GOARCH=amd64 go build -ldflags \"-X main.buildSHA=${SHA}\" . && ./travis_docker_push.sh
+  - go test . && GOOS=linux GOARCH=amd64 go build -ldflags "-X main.buildSHA=${SHA}" . && ./travis_docker_push.sh

--- a/main.go
+++ b/main.go
@@ -65,6 +65,9 @@ func main() {
 	if err != nil {
 		log.Fatalf("unable to load configuration: %s", err)
 	}
+	loadConfigMetrics.Set("last_config_check", cLoader.lastCheck)
+	loadConfigMetrics.Set("last_config_set", cLoader.lastSet)
+
 	conf := cLoader.Get()
 
 	go func() {

--- a/main.go
+++ b/main.go
@@ -103,7 +103,6 @@ func main() {
 	m := http.NewServeMux()
 	m.HandleFunc("/debug/", func(w http.ResponseWriter, r *http.Request) {
 		conf := cLoader.Get()
-		log.Printf("in / handler: %#v %t %s %s", conf, r.URL.Path, r.RemoteAddr, r.Header.Get("User-Agent"))
 		if !conf.AllowRemoteDebug && isBlockedRequest(r) {
 			http.NotFound(w, r)
 			return

--- a/main.go
+++ b/main.go
@@ -106,6 +106,10 @@ func main() {
 			http.NotFound(w, r)
 			return
 		}
+		if r.URL.Path == "/debug/build" {
+			w.Write([]byte("SHA: " + buildSHA))
+			return
+		}
 		http.DefaultServeMux.ServeHTTP(w, r)
 	})
 

--- a/main.go
+++ b/main.go
@@ -293,6 +293,7 @@ func domainMismatch(cert *x509.Certificate, domains []string) bool {
 }
 
 func isBlockedRequest(r *http.Request) bool {
+	log.Println("blocked request check", r.URL.Path, r.RemoteAddr)
 	if r.URL.Path == "/debug" || strings.HasPrefix(r.URL.Path, "/debug/") {
 		i := strings.Index(r.RemoteAddr, ":")
 		if i < 0 {

--- a/main.go
+++ b/main.go
@@ -40,6 +40,7 @@ var (
 	storeSecretMetrics = (&expvar.Map{}).Init()
 	loadConfigMetrics  = (&expvar.Map{}).Init()
 	stageMetrics       = expvar.NewMap("")
+	buildSHA           = "<debug>"
 )
 
 func main() {
@@ -105,6 +106,10 @@ func main() {
 		log.Printf("in / handler: %#v %t %s %s", conf, r.URL.Path, r.RemoteAddr, r.Header.Get("User-Agent"))
 		if !conf.AllowRemoteDebug && isBlockedRequest(r) {
 			http.NotFound(w, r)
+			return
+		}
+		if r.URL.Path == "/debug/build" {
+			w.Write([]byte("SHA: " + buildSHA))
 			return
 		}
 		http.DefaultServeMux.ServeHTTP(w, r)

--- a/main.go
+++ b/main.go
@@ -102,7 +102,7 @@ func main() {
 	m := http.NewServeMux()
 	m.HandleFunc("/debug/", func(w http.ResponseWriter, r *http.Request) {
 		conf := cLoader.Get()
-		log.Printf("in / handler: %#v %t %s %s", conf, conf.AllowRemoteDebug, r.URL.Path, r.RemoteAddr)
+		log.Printf("in / handler: %#v %t %s %s", conf, r.URL.Path, r.RemoteAddr, r.Header.Get("User-Agent"))
 		if !conf.AllowRemoteDebug && isBlockedRequest(r) {
 			http.NotFound(w, r)
 			return

--- a/main.go
+++ b/main.go
@@ -301,7 +301,6 @@ func domainMismatch(cert *x509.Certificate, domains []string) bool {
 }
 
 func isBlockedRequest(r *http.Request) bool {
-	log.Println("blocked request check", r.URL.Path, r.RemoteAddr)
 	if r.URL.Path == "/debug" || strings.HasPrefix(r.URL.Path, "/debug/") {
 		i := strings.Index(r.RemoteAddr, ":")
 		if i < 0 {

--- a/main.go
+++ b/main.go
@@ -102,7 +102,7 @@ func main() {
 	m := http.NewServeMux()
 	m.HandleFunc("/debug/", func(w http.ResponseWriter, r *http.Request) {
 		conf := cLoader.Get()
-		log.Printf("in / handler: %q %t %t %s %s", conf, conf.AllowRemoteDebug, isBlockedRequest(r), r.URL.Path, r.RemoteAddr)
+		log.Printf("in / handler: %#v %t %s %s", conf, conf.AllowRemoteDebug, r.URL.Path, r.RemoteAddr)
 		if !conf.AllowRemoteDebug && isBlockedRequest(r) {
 			http.NotFound(w, r)
 			return

--- a/main.go
+++ b/main.go
@@ -106,10 +106,6 @@ func main() {
 			http.NotFound(w, r)
 			return
 		}
-		if r.URL.Path == "/debug/build" {
-			w.Write([]byte("SHA: " + buildSHA))
-			return
-		}
 		http.DefaultServeMux.ServeHTTP(w, r)
 	})
 

--- a/main.go
+++ b/main.go
@@ -102,6 +102,7 @@ func main() {
 	m := http.NewServeMux()
 	m.HandleFunc("/debug/", func(w http.ResponseWriter, r *http.Request) {
 		conf := cLoader.Get()
+		log.Printf("in / handler: %q %t %t %s %s", conf, conf.AllowRemoteDebug, isBlockedRequest(r), r.URL.Path, r.RemoteAddr)
 		if !conf.AllowRemoteDebug && isBlockedRequest(r) {
 			http.NotFound(w, r)
 			return


### PR DESCRIPTION
This adds expvar metrics for when the config file was last checked and the last time it was actually set.

It also adds /debug/build to the debug handlers so that folks can query what SHA is running on their machine.
