### PR TITLE
add option to run server as HTTPS-only

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,4 @@ FROM golang
 
 COPY ./lekube /go/bin/
 
-ENTRYPOINT ["lekube", "-conf", "/etc/lekube/lekube.json"]
+CMD ["lekube", "-conf", "/etc/lekube/lekube.json"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,4 @@ FROM golang
 
 COPY ./lekube /go/bin/
 
-CMD ["lekube", "-conf", "/etc/lekube/lekube.json"]
+ENTRYPOINT ["lekube", "-conf", "/etc/lekube/lekube.json"]

--- a/config.go
+++ b/config.go
@@ -158,7 +158,7 @@ func validateConf(conf *allConf) error {
 	}
 
 	if conf.UseProd == nil {
-		return fmt.Errorf("'use_prod' must be set to `false` (to use the staging Let's Encrypt API with untrusted certs and higher rate limits), or `true` (to use the production Let's Encrypt API with working certs but much lower rate limits. lekube strongly recommends setting this to `false` until you've seen your staging certs be successfully created.")
+		return fmt.Errorf("'use_prod' must be set to `false` or `true`. `false will mean use the staging Let's Encrypt API (which has untrusted certs and higher rate limits), and `true` means use the production Let's Encrypt API with working certs but much lower rate limits. lekube strongly recommends setting this to `false` until you've seen your staging certs be successfully created.")
 	}
 
 	secs := make(map[nsSecName]bool)

--- a/config.go
+++ b/config.go
@@ -111,6 +111,7 @@ type allConf struct {
 	UseProd          *bool         `json:"use_prod"`
 	AllowRemoteDebug bool          `json:"allow_remote_debug"`
 	Secrets          []*secretConf `json:"secrets"`
+	TLSDir           string        `json:"tls_dir"`
 }
 
 type secretConf struct {

--- a/main.go
+++ b/main.go
@@ -114,20 +114,6 @@ func main() {
 	m.Handle("/", responder)
 
 	go func() {
-		var err error
-		if conf.TLSDir == "" {
-			err = http.ListenAndServe(*httpAddr, m)
-		} else {
-			crt := filepath.Join(conf.TLSDir, "tls.crt")
-			key := filepath.Join(conf.TLSDir, "tls.key")
-			err = http.ListenAndServeTLS(*httpAddr, crt, key, m)
-		}
-		if err != nil {
-			log.Fatalf("unable to boot server: %s", err)
-		}
-	}()
-
-	go func() {
 		tick := time.NewTicker(*betweenChecksDur)
 		run(lcm, kubeClient, cLoader)
 		for range tick.C {
@@ -141,6 +127,17 @@ func main() {
 			log.Fatalf("lost the watch on the config file: %s", err)
 		}
 	}()
+
+	if conf.TLSDir == "" {
+		err = http.ListenAndServe(*httpAddr, m)
+	} else {
+		crt := filepath.Join(conf.TLSDir, "tls.crt")
+		key := filepath.Join(conf.TLSDir, "tls.key")
+		err = http.ListenAndServeTLS(*httpAddr, crt, key, m)
+	}
+	if err != nil {
+		log.Fatalf("unable to boot server: %s", err)
+	}
 }
 
 func run(lcm *leClientMaker, client core13.CoreInterface, cLoader *confLoader) {

--- a/testdata/test.json
+++ b/testdata/test.json
@@ -2,6 +2,7 @@
   "email": "fake@example.com",
   "use_prod": true,
   "allow_remote_debug": true,
+  "tls_dir": "./testdata/tls",
   "secrets": [
     {
       "namespace": "default",

--- a/testdata/tls/tls.crt
+++ b/testdata/tls/tls.crt
@@ -1,0 +1,22 @@
+-----BEGIN CERTIFICATE-----
+MIIDuDCCAxqgAwIBAgIJAOWWmA/fPFkxMAoGCCqGSM49BAMCMBQxEjAQBgNVBAMM
+CWxvY2FsaG9zdDAeFw0xNjA4MjAwNzI3NDlaFw0yNjA4MTgwNzI3NDlaMBQxEjAQ
+BgNVBAMMCWxvY2FsaG9zdDCCAlwwggHPBgcqhkjOPQIBMIIBwgIBATBNBgcqhkjO
+PQEBAkIB////////////////////////////////////////////////////////
+//////////////////////////////8wgZ4EQgH/////////////////////////
+/////////////////////////////////////////////////////////////ARB
+UZU+uWGOHJofkpohoLaFQO6i2nJbmbMV87i0iZGO8QnhVhk5Uex+k3sWUsC9O7G/
+BzVz34g9LDTx70Uf1GtQPwADFQDQnogAKRy4U5bMZxc5MoSqoNpkugSBhQQAxoWO
+BrcEBOnNnj7LZiOVtEKcZIE5BT+1Ifgor2BrTT26oUted+/nWSj+HcEnov+o3jNI
+s8GFakKb+X5+McLlvWYBGDkpaniaO8AEXIpftCx9G9mY9URJV5tEaBevvRcnPmYs
+l+5ymV70JkDFULkBP60HYTU8cIaicsJAiL6Udp/RZlACQgH/////////////////
+//////////////////////////pRhoeDvy+Wa3/MAUj3CaXQO7XJuImcR667b7ce
+kThkCQIBAQOBhgAEAWuN6VNcZuBEL4RpfF0KYcQeAJP+S7sr7BiO89VYRUchYo+v
+QMxyX+t56tH5OTipZLZXQp/p6OBU1drvn8fXSlC6AM7FAC2hvBI1lBVX+j5MYMaM
++UuobCh2U3AXEXimnC50rWNl/zKTZAexxBI9csX2sz6Xhqn7aUNEnofGNUY04Uqp
+o1AwTjAdBgNVHQ4EFgQUUdl4ZcM8EG18LDYrSXQyyPO/pD4wHwYDVR0jBBgwFoAU
+Udl4ZcM8EG18LDYrSXQyyPO/pD4wDAYDVR0TBAUwAwEB/zAKBggqhkjOPQQDAgOB
+iwAwgYcCQgD3Yo+/i/A0ldoE+ay3KCntUNIIZeEU1RtzO7gomrYx7R5+XvayUG9n
+IRxXDv8daGJ0cGnHvzQZh46dXRLUR7TnXQJBVmW7vgDXMUUpmfevtP3SzihYkqMP
+s9UPbL8MF8n+ZJsGId7Vklo3fBbfvuG/1DOTCY9avl07r4YaW6Y/HjRbuq0=
+-----END CERTIFICATE-----

--- a/testdata/tls/tls.key
+++ b/testdata/tls/tls.key
@@ -1,0 +1,29 @@
+-----BEGIN EC PARAMETERS-----
+MIIBwgIBATBNBgcqhkjOPQEBAkIB////////////////////////////////////
+//////////////////////////////////////////////////8wgZ4EQgH/////
+////////////////////////////////////////////////////////////////
+/////////////////ARBUZU+uWGOHJofkpohoLaFQO6i2nJbmbMV87i0iZGO8Qnh
+Vhk5Uex+k3sWUsC9O7G/BzVz34g9LDTx70Uf1GtQPwADFQDQnogAKRy4U5bMZxc5
+MoSqoNpkugSBhQQAxoWOBrcEBOnNnj7LZiOVtEKcZIE5BT+1Ifgor2BrTT26oUte
+d+/nWSj+HcEnov+o3jNIs8GFakKb+X5+McLlvWYBGDkpaniaO8AEXIpftCx9G9mY
+9URJV5tEaBevvRcnPmYsl+5ymV70JkDFULkBP60HYTU8cIaicsJAiL6Udp/RZlAC
+QgH///////////////////////////////////////////pRhoeDvy+Wa3/MAUj3
+CaXQO7XJuImcR667b7cekThkCQIBAQ==
+-----END EC PARAMETERS-----
+-----BEGIN EC PRIVATE KEY-----
+MIICnQIBAQRCAKtJrOKJcM/uf8Ip1wlD1W+fDNN6TZg23gqSZoGVZxy6N0DJC+C0
+ZzyHMkpp1jY6hA9GTSb72xwG0R8q+RZQyqC8oIIBxjCCAcICAQEwTQYHKoZIzj0B
+AQJCAf//////////////////////////////////////////////////////////
+////////////////////////////MIGeBEIB////////////////////////////
+//////////////////////////////////////////////////////////wEQVGV
+PrlhjhyaH5KaIaC2hUDuotpyW5mzFfO4tImRjvEJ4VYZOVHsfpN7FlLAvTuxvwc1
+c9+IPSw08e9FH9RrUD8AAxUA0J6IACkcuFOWzGcXOTKEqqDaZLoEgYUEAMaFjga3
+BATpzZ4+y2YjlbRCnGSBOQU/tSH4KK9ga009uqFLXnfv51ko/h3BJ6L/qN4zSLPB
+hWpCm/l+fjHC5b1mARg5KWp4mjvABFyKX7QsfRvZmPVESVebRGgXr70XJz5mLJfu
+cple9CZAxVC5AT+tB2E1PHCGonLCQIi+lHaf0WZQAkIB////////////////////
+///////////////////////6UYaHg78vlmt/zAFI9wml0Du1ybiJnEeuu2+3HpE4
+ZAkCAQGhgYkDgYYABAFrjelTXGbgRC+EaXxdCmHEHgCT/ku7K+wYjvPVWEVHIWKP
+r0DMcl/reerR+Tk4qWS2V0Kf6ejgVNXa75/H10pQugDOxQAtobwSNZQVV/o+TGDG
+jPlLqGwodlNwFxF4ppwudK1jZf8yk2QHscQSPXLF9rM+l4ap+2lDRJ6HxjVGNOFK
+qQ==
+-----END EC PRIVATE KEY-----


### PR DESCRIPTION
Add config option `tlsDir` that forces the lekube HTTP server to run as HTTPS. This is useful when run as a backend system in an architecture that requires HTTPS.