### PR TITLE
gather certs as soon as config changes are detected

### DIFF
--- a/lekube_test.go
+++ b/lekube_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http/httptest"
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestConfigLoadGoldenPath(t *testing.T) {
@@ -21,6 +22,10 @@ func TestConfigLoadGoldenPath(t *testing.T) {
 	}
 	if !c.AllowRemoteDebug {
 		t.Errorf("allow_remote_debug: want %t, got %t", true, c.AllowRemoteDebug)
+	}
+	expectedCheck := jsonDuration(3 * time.Minute)
+	if c.ConfigCheckInterval != expectedCheck {
+		t.Errorf("config_check_interval: want %s, got %s", expectedCheck, c.ConfigCheckInterval)
 	}
 	defaultNS := "default"
 	stagingNS := "staging"
@@ -56,6 +61,18 @@ func TestConfigLoadGoldenPath(t *testing.T) {
 		if !reflect.DeepEqual(sec, c.Secrets[i]) {
 			t.Errorf("secret %d: want %#v, got %#v", i, sec, c.Secrets[i])
 		}
+	}
+}
+
+func TestConfigLoadDefaultConfigCheckInterval(t *testing.T) {
+	cl, err := newConfLoader("./testdata/no_config_check_interval.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := cl.Get()
+	expected := jsonDuration(30 * time.Second)
+	if c.ConfigCheckInterval != expected {
+		t.Errorf("default config_check_interval: want %s, got %s", expected, c.ConfigCheckInterval)
 	}
 }
 

--- a/lekube_test.go
+++ b/lekube_test.go
@@ -8,11 +8,14 @@ import (
 )
 
 func TestConfigLoadGoldenPath(t *testing.T) {
-	cl, err := newConfLoader("./testdata/test.json")
+	cl, c, err := newConfLoader("./testdata/test.json")
 	if err != nil {
 		t.Fatal(err)
 	}
-	c := cl.Get()
+	c2 := cl.Get()
+	if c != c2 {
+		t.Errorf("config pointers returned by newConfLoader and Get should be the same but were not")
+	}
 	email := "fake@example.com"
 	if c.Email != email {
 		t.Errorf("email: want %#v, got %#v", email, c.Email)
@@ -65,11 +68,14 @@ func TestConfigLoadGoldenPath(t *testing.T) {
 }
 
 func TestConfigLoadDefaultConfigCheckInterval(t *testing.T) {
-	cl, err := newConfLoader("./testdata/no_config_check_interval.json")
+	cl, c, err := newConfLoader("./testdata/no_config_check_interval.json")
 	if err != nil {
 		t.Fatal(err)
 	}
-	c := cl.Get()
+	c2 := cl.Get()
+	if c != c2 {
+		t.Errorf("config pointers returned by newConfLoader and Get should be the same but were not")
+	}
 	expected := jsonDuration(30 * time.Second)
 	if c.ConfigCheckInterval != expected {
 		t.Errorf("default config_check_interval: want %s, got %s", expected, c.ConfigCheckInterval)

--- a/testdata/no_config_check_interval.json
+++ b/testdata/no_config_check_interval.json
@@ -1,0 +1,11 @@
+{
+  "email": "fake@example.com",
+  "use_prod": false,
+  "secrets": [
+    {
+      "namespace": "default",
+      "name": "test",
+      "domains": ["example.com"]
+    }
+  ]
+}

--- a/testdata/test.json
+++ b/testdata/test.json
@@ -3,6 +3,7 @@
   "use_prod": true,
   "allow_remote_debug": true,
   "tls_dir": "./testdata/tls",
+  "config_check_interval": "3m",
   "secrets": [
     {
       "namespace": "default",


### PR DESCRIPTION
Poll the config file in a much shorter by default (but configurable) interval and gather certs as soon as a successful config change is detected.