### PR TITLE
remove typoed and unnecessary env var

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ go:
 
 sudo: required
 
-env:
-  - GO111MODULES=on
-
 services:
   - docker
 


### PR DESCRIPTION
`GO111MODULE` would be the right name, but it's already set to `auto` by Travis CI.