### PR TITLE
correct naming of lekube errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -111,8 +111,7 @@ func main() {
 			log.Fatalf("unable to get cluster-name InstanceAttributeValue from GCE emetadata")
 		}
 		exporter, err := stackdriver.NewExporter(stackdriver.Options{
-			ProjectID:    creds.ProjectID,
-			MetricPrefix: "lekube",
+			ProjectID: creds.ProjectID,
 			Resource: &monitoredres.MonitoredResource{
 				Type: "k8s_container",
 				Labels: map[string]string{
@@ -456,7 +455,7 @@ func countViews(measures ...*stats.Int64Measure) []*view.View {
 	out := make([]*view.View, len(measures))
 	for i, m := range measures {
 		out[i] = &view.View{
-			Name:        m.Name(),
+			Name:        "lekube/" + m.Name(),
 			Description: m.Description(),
 			Measure:     m,
 			Aggregation: view.Count(),
@@ -469,7 +468,7 @@ func latestViews(measures ...*stats.Int64Measure) []*view.View {
 	out := make([]*view.View, len(measures))
 	for i, m := range measures {
 		out[i] = &view.View{
-			Name:        m.Name(),
+			Name:        "lekube/" + m.Name(),
 			Description: m.Description(),
 			Measure:     m,
 			Aggregation: view.LastValue(),


### PR DESCRIPTION
MetricPrefix was for the display name, not the actual metric name (and is
deprecated).

The place we fix it is kind of hacky, but opencensus doesn't help us much.