### PR TITLE
upgrade to Go 1.14.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.14
+- 1.14.1
 sudo: required
 services:
 - docker


### PR DESCRIPTION
Travis CI config is actually what control what version of Go we build with.

We don't need the -mod=vendor (which we should have been using) anymore, but
build breaks are because of that, probably.