### PR TITLE
allow dependabot to update more packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,11 @@ updates:
       interval: "weekly"
     allow:
       - dependency-type: "all"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Specifically, allow dependabot to update the docker images we reference
in our Dockerfile and the modules we use in GitHub Actions.
