### PR TITLE
update deploy process

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,6 @@ on:
 concurrency: production
 
 env:
-  PROJECT_ID: ${{ secrets.GKE_PROJECT }}
   GKE_CLUSTER: dg
   GKE_ZONE: us-central1-c
   DEPLOYMENT_NAME: lekube
@@ -36,27 +35,29 @@ jobs:
           go test -race ./...
 
       # Setup gcloud CLI
-      - uses: google-github-actions/setup-gcloud@v0.6.0
+      - id: 'auth'
+        uses: 'google-github-actions/auth@v0'
         with:
-          service_account_key: ${{ secrets.GKE_SA_KEY }}
-          project_id: ${{ secrets.GKE_PROJECT }}
+          credentials_json: '${{ secrets.GKE_SA_KEY }}'
+
+      - id: 'get-credentials'
+        uses: 'google-github-actions/get-gke-credentials@v0'
+        with:
+          cluster_name: ${{ env.GKE_CLUSTER }}
+          location: ${{ env.GKE_ZONE }}
+
+      - uses: google-github-actions/setup-gcloud@v0.6.0
 
       # Configure Docker to use the gcloud command-line tool as a credential
       # helper for authentication
       - run: |-
-          gcloud --quiet auth configure-docker
-      # Get the GKE credentials so we can deploy to the cluster
-      - uses: google-github-actions/get-gke-credentials@v0.7.0
-        with:
-          cluster_name: ${{ env.GKE_CLUSTER }}
-          location: ${{ env.GKE_ZONE }}
-          credentials: ${{ secrets.GKE_SA_KEY }}
+          gcloud --quiet auth configure-docker gcr.io
 
       # Build the Docker image
       - name: Build
         run: |-
           docker build \
-            --tag "gcr.io/$PROJECT_ID/$IMAGE:$GITHUB_SHA" \
+            --tag "gcr.io/${{ steps.auth.outputs.project_id }}/$IMAGE:$GITHUB_SHA" \
             --build-arg GITHUB_SHA="$GITHUB_SHA" \
             --build-arg GITHUB_REF="$GITHUB_REF" \
             .
@@ -64,7 +65,7 @@ jobs:
       # Push the Docker image to Google Container Registry
       - name: Publish
         run: |-
-          docker push "gcr.io/$PROJECT_ID/$IMAGE:$GITHUB_SHA"
+          docker push "gcr.io/${{ steps.auth.outputs.project_id }}/$IMAGE:$GITHUB_SHA"
 
       # Grab the image's SHA256 so we can use it instead of a tag (that can be
       # modified underneath us). This has to be done after the image has been
@@ -72,7 +73,7 @@ jobs:
       - name: Capture Docker image's SHA256
         id: image
         run: |-
-          FULLIMAGE=$(docker inspect --format='{{index .RepoDigests 0}}' gcr.io/$PROJECT_ID/$IMAGE:$GITHUB_SHA);
+          FULLIMAGE=$(docker inspect --format='{{index .RepoDigests 0}}' gcr.io/${{ steps.auth.outputs.project_id }}/$IMAGE:$GITHUB_SHA);
           echo "::set-output name=fullimage::${FULLIMAGE}"
       - name: Update GKE deployment
         run: |-


### PR DESCRIPTION
Use a less deprecated means of authenticating with gcloud with the new
google-github-actions/auth action.

Only configure docker gcloud auth for gcr.io to remove a warning message
(this is the change to the `configure-docker` line).

Use the new gcloud auth step's project_id var instead of the
$PROJECT_ID. After this ships, we can delete that from the GitHub
secrets.
