### PR TITLE
replace deprecated set-output GHA command

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,7 +74,7 @@ jobs:
         id: image
         run: |-
           FULLIMAGE=$(docker inspect --format='{{index .RepoDigests 0}}' gcr.io/${{ steps.auth.outputs.project_id }}/$IMAGE:$GITHUB_SHA);
-          echo "::set-output name=fullimage::${FULLIMAGE}"
+          echo "fullimage=${FULLIMAGE}" >> $GITHUB_OUTPUT
       - name: Update GKE deployment
         run: |-
           kubectl -n prod set image deployment/$DEPLOYMENT_NAME $IMAGE="${{ steps.image.outputs.fullimage }}"


### PR DESCRIPTION
The set-output magic string parameter is deprecated in GitHub Actions. Instead, use echoing to `$GITHUB_OUTPUT`

See https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter