### PR TITLE
sort go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,18 +3,12 @@ module github.com/jmhodges/lekube
 go 1.20
 
 require (
-	cloud.google.com/go/monitoring v1.13.1 // indirect
-	cloud.google.com/go/trace v1.9.0 // indirect
-	github.com/aws/aws-sdk-go v1.43.31 // indirect
-	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+	cloud.google.com/go/compute/metadata v0.2.3
+	contrib.go.opencensus.io/exporter/stackdriver v0.13.14
 	go.opencensus.io v0.24.0
 	golang.org/x/crypto v0.9.0
-	golang.org/x/net v0.10.0 // indirect
 	golang.org/x/oauth2 v0.8.0
-	golang.org/x/sys v0.8.0 // indirect
-	golang.org/x/text v0.9.0 // indirect
 	golang.org/x/time v0.3.0
-	google.golang.org/api v0.118.0 // indirect
 	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1
 	gopkg.in/square/go-jose.v2 v2.6.0
 	k8s.io/api v0.26.0
@@ -23,12 +17,10 @@ require (
 )
 
 require (
-	cloud.google.com/go/compute/metadata v0.2.3
-	contrib.go.opencensus.io/exporter/stackdriver v0.13.14
-)
-
-require (
 	cloud.google.com/go/compute v1.19.0 // indirect
+	cloud.google.com/go/monitoring v1.13.1 // indirect
+	cloud.google.com/go/trace v1.9.0 // indirect
+	github.com/aws/aws-sdk-go v1.43.31 // indirect
 	github.com/census-instrumentation/opencensus-proto v0.4.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.10.2 // indirect
@@ -37,6 +29,7 @@ require (
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.22.3 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/gnostic v0.5.7-v3refs // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
@@ -54,8 +47,12 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/prometheus/prometheus v0.35.0 // indirect
 	github.com/rogpeppe/go-internal v1.10.0 // indirect
+	golang.org/x/net v0.10.0 // indirect
 	golang.org/x/sync v0.1.0 // indirect
+	golang.org/x/sys v0.8.0 // indirect
 	golang.org/x/term v0.8.0 // indirect
+	golang.org/x/text v0.9.0 // indirect
+	google.golang.org/api v0.118.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/grpc v1.55.0 // indirect
 	google.golang.org/protobuf v1.30.0 // indirect


### PR DESCRIPTION
Give `go mod tidy` the opportunity to sort the go.mod file into its
preferred two require format by consolidating the 3 require directories
into 1 and then running it.
