### PR TITLE
renew certificates when algos don't match

### DIFF
--- a/le.go
+++ b/le.go
@@ -50,6 +50,8 @@ func (lc *leClient) CreateCert(ctx context.Context, sconf *secretConf) (*newCert
 	var priv crypto.PrivateKey
 	var pblock *pem.Block
 	var sigAlg x509.SignatureAlgorithm
+	// If you adjust this UseRSA code, be sure to also adjust
+	// certPublicKeyAlgoDoesntMatch in main.go
 	if sconf.UseRSA {
 		k, err := rsa.GenerateKey(rand.Reader, 2048)
 		if err != nil {


### PR DESCRIPTION
When the public key algorithm of the certificate doesn't match the one
requested in the config by `UseRSA`, renew the certificate.

Currently, the only supported public key algorithms are RSA and ECDSA.
