### PR TITLE
use newer debian version in Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
 # Copyright 2021 Jeffrey M Hodges.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM amd64/golang:1.21.3@sha256:d0214956a9c50c300e430c1f6c0a820007ace238e5242c53762e61b344659e05 as build
+# When a new debian stable comes out, we have to update this and the distroless
+# base image at the same time. Dependabot won't do it for us, owing to how it
+# interprets tags as release histories not versions.
+FROM golang:1.21.3-bookworm@sha256:24a09375a6216764a3eda6a25490a88ac178b5fcb9511d59d0da5ebf9e496474 as build
 
 WORKDIR /go/src/github.com/jmhodges/lekube
 ADD . /go/src/github.com/jmhodges/lekube
@@ -9,6 +12,6 @@ ADD . /go/src/github.com/jmhodges/lekube
 RUN go build -o /go/bin/lekube
 
 # Now copy it into our base image.
-FROM gcr.io/distroless/static-debian12@sha256:0c3d36f317d6335831765546ece49b60ad35933250dc14f43f0fd1402450532e
+FROM gcr.io/distroless/base-debian12
 COPY --from=build /go/bin/lekube /
 CMD ["/lekube", "-conf", "/etc/lekube/lekube.json"]


### PR DESCRIPTION
Unfortunately, it seems like the `golang:1.21.3` images and the
`gcr.io/distroless/base` images are based on different debian versions,
so in order to keep them consistent, we have to specify both debian
versions explicitly.

That means when a new stable debian is released, we'll have to update
the versions here explicitly and can't rely on Dependabot to update them
ourselves.

The `golang` images use the Debian code name (bookworm), while the
distroless images uses its version number (12).
