### PR TITLE
use a distro-agnostic Go image tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,7 @@
 # Copyright 2021 Jeffrey M Hodges.
 # SPDX-License-Identifier: Apache-2.0
 
-# When a new debian stable comes out, we have to update this and the distroless
-# base image at the same time. Dependabot won't do it for us, owing to how it
-# interprets tags as release histories not versions.
-FROM golang:1.21.6-bookworm@sha256:cbee5d27649be9e3a48d4d152838901c65d7f8e803f4cc46b53699dd215b555f as build
+FROM golang:1.21.6@sha256:cbee5d27649be9e3a48d4d152838901c65d7f8e803f4cc46b53699dd215b555f as build
 
 WORKDIR /go/src/github.com/jmhodges/lekube
 ADD . /go/src/github.com/jmhodges/lekube


### PR DESCRIPTION
Since we're very unlikely to have Ubuntu distribution-specific issues with our Go
build, we can use the distribution-agnostic Go image tag.

This will make it possible for dependabot to update our Go image tag
even when the new Go version is only on a newer Ubuntu distribution.

We could likely use the distroless Go docker image instead, but this
minimizes the change for now. Future work!
