### PR TITLE
only look at direct Go deps in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,6 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 15
-    allow:
-      - dependency-type: "all"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:


### PR DESCRIPTION
This might lessen some of our PR churn.