### PR TITLE
attempt to make dependabot group otel bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,11 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 15
+    groups:
+      otel:
+        applies-to: version-updates
+        patterns:
+          - "go.opentelemetry.io/otel*"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:


### PR DESCRIPTION
This is an attempt to get dependabot to group all the otel version bumps
into a single PR. I believe I've read the docs correctly but we may need
to wait a few weeks to see if it worked.
