### PR TITLE
add contrib deps to the otel dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
         applies-to: version-updates
         patterns:
           - "go.opentelemetry.io/otel*"
+          - "go.opentelemetry.io/contrib*"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:


### PR DESCRIPTION
This adds the contrib libraries to the dependabot group for our
OpenTelemetry dependencies.
