### PR TITLE
add gcp otel libs to otel dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,8 @@ updates:
         patterns:
           - "go.opentelemetry.io/otel*"
           - "go.opentelemetry.io/contrib*"
+          - "github.com/GoogleCloudPlatform/opentelemetry-operations-go"
+          - "github.com/GoogleCloudPlatform/opentelemetry-operations-go/*"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:


### PR DESCRIPTION
Group the GCP OpenTelemetry libraries together with the other
OpenTelemetry libraries in the dependabot-made version bump PRs.
