### PR TITLE
add boot time delay of checking certs

### DIFF
--- a/config.go
+++ b/config.go
@@ -68,13 +68,14 @@ func (cl *confLoader) Get() *allConf {
 	cl.confMu.Lock()
 	defer cl.confMu.Unlock()
 	conf := &allConf{
-		Email:               cl.conf.Email,
-		UseProd:             cl.conf.UseProd != nil && *cl.conf.UseProd,
-		AllowRemoteDebug:    cl.conf.AllowRemoteDebug,
-		Secrets:             []*secretConf{},
-		TLSDir:              cl.conf.TLSDir,
-		ConfigCheckInterval: time.Duration(cl.conf.ConfigCheckInterval),
-		StartRenewDur:       time.Duration(cl.conf.StartRenewDur),
+		Email:                cl.conf.Email,
+		UseProd:              cl.conf.UseProd != nil && *cl.conf.UseProd,
+		AllowRemoteDebug:     cl.conf.AllowRemoteDebug,
+		Secrets:              []*secretConf{},
+		TLSDir:               cl.conf.TLSDir,
+		ConfigCheckInterval:  time.Duration(cl.conf.ConfigCheckInterval),
+		ConfigCheckBootDelay: time.Duration(cl.conf.ConfigCheckBootDelay),
+		StartRenewDur:        time.Duration(cl.conf.StartRenewDur),
 	}
 	conf.Secrets = make([]*secretConf, len(cl.conf.Secrets))
 	for i, s := range cl.conf.Secrets {
@@ -171,6 +172,11 @@ type internalAllConf struct {
 	TLSDir              string        `json:"tls_dir"`
 	ConfigCheckInterval jsonDuration  `json:"config_check_interval"`
 	StartRenewDur       jsonDuration  `json:"start_renew_duration"`
+	// ConfigCheckBootDelay is how long to wait after boot before starting to
+	// check if the certs need updating. This prevents lekube from kicking off
+	// requests from Let's Encrypt before Let's Encrypt can see the node. It
+	// defaults to 1 minute.
+	ConfigCheckBootDelay jsonDuration `json:"config_check_boot_delay"`
 }
 
 type allConf struct {
@@ -180,7 +186,14 @@ type allConf struct {
 	Secrets             []*secretConf
 	TLSDir              string
 	ConfigCheckInterval time.Duration
-	StartRenewDur       time.Duration
+
+	// ConfigCheckBootDelay is how long to wait after boot before starting to
+	// check if the certs need updating. This prevents lekube from kicking off
+	// requests from Let's Encrypt before Let's Encrypt can see the node. It
+	// defaults to 1 minute.
+	ConfigCheckBootDelay time.Duration
+
+	StartRenewDur time.Duration
 }
 
 type secretConf struct {
@@ -257,6 +270,9 @@ func unmarshalConf(jsonData []byte) (*internalAllConf, error) {
 	}
 	if conf.StartRenewDur == jsonDuration(0) {
 		conf.StartRenewDur = jsonDuration(3 * 7 * 24 * time.Hour)
+	}
+	if conf.ConfigCheckBootDelay == jsonDuration(0) {
+		conf.ConfigCheckBootDelay = jsonDuration(1 * time.Minute)
 	}
 	return conf, err
 }

--- a/lekube_test.go
+++ b/lekube_test.go
@@ -37,6 +37,10 @@ func TestConfigLoadGoldenPath(t *testing.T) {
 	if c.StartRenewDur != expectedRenewDur {
 		t.Errorf("start_renew_dur: want %s, got %s", expectedRenewDur, c.StartRenewDur)
 	}
+	expectedBootDelay := 2 * time.Minute
+	if c.ConfigCheckBootDelay != expectedBootDelay {
+		t.Errorf("config_check_boot_delay: want %s, got %s", expectedBootDelay, c.ConfigCheckBootDelay)
+	}
 	defaultNS := "default"
 	stagingNS := "staging"
 
@@ -86,6 +90,10 @@ func TestConfigLoadDefaultConfigCheckInterval(t *testing.T) {
 	expectedRenewDur := 504 * time.Hour
 	if c.StartRenewDur != expectedRenewDur {
 		t.Errorf("default start_renew_dur: want %s, got %s", expectedRenewDur, c.StartRenewDur)
+	}
+	expectedBootDelay := 1 * time.Minute
+	if c.ConfigCheckBootDelay != expectedBootDelay {
+		t.Errorf("default config_check_boot_delay: want %s, got %s", expectedBootDelay, c.ConfigCheckBootDelay)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -208,6 +208,7 @@ func main() {
 	}()
 	go func() {
 		conf := conf
+		time.Sleep(conf.ConfigCheckBootDelay)
 		runCh <- conf
 		t := time.NewTicker(1 * time.Hour)
 		for {

--- a/testdata/test.json
+++ b/testdata/test.json
@@ -4,6 +4,7 @@
   "allow_remote_debug": true,
   "tls_dir": "./testdata/tls",
   "config_check_interval": "3m",
+  "config_check_boot_delay": "2m",
   "start_renew_duration": "3h",
   "secrets": [
     {


### PR DESCRIPTION
Sometimes lekube boots up and starts emitting Let's Encrypt requests
before the networking in front of its server has fully connected to it.

This `config_check_boot_delay` delays the first check of the certs by a
configured amount of time. It defaults to 1 minute.
