### PR TITLE
Guard against nil block from pem.Decode in getK8SSecret

### DIFF
--- a/main.go
+++ b/main.go
@@ -391,6 +391,11 @@ func fetchK8SSecret(ctx context.Context, client corev1.SecretInterface, secretNa
 		return nil, nil
 	}
 	block, _ := pem.Decode(b)
+	if block == nil {
+		// tls.crt isn't valid PEM, but we don't actually need it to do our
+		// work.
+		return &tlsSecret{Secret: sec}, nil
+	}
 	certs, err := x509.ParseCertificates(block.Bytes)
 	if err != nil {
 		// unable to parse certificates already in the Secret, but we don't


### PR DESCRIPTION
`pem.Decode` returns a nil `*Block` when the secret's `tls.crt` data isn't valid PEM. The subsequent `x509.ParseCertificates(block.Bytes)` call would then panic before reaching the existing error-tolerant fallback.

Treat a nil block the same as a parse failure and continue without the existing leaf cert — matches the intent of the comment already there ("we don't actually need it to do our work").