### PR TITLE
Remove stale 2022-01 Let's Encrypt revocation check

### DIFF
--- a/main.go
+++ b/main.go
@@ -316,9 +316,6 @@ func run(lcm *leClientMaker, client corev1.CoreV1Interface, conf *allConf, leTim
 		} else if domainMismatch(tlsSec.Cert, secConf.Domains) {
 			log.Printf("domain mismatch between cert and secret %s", secConf.FullName())
 			refreshCert = true
-		} else if isRevokedLetsEncrypt(tlsSec.Cert) {
-			log.Printf("Let's Encrypt revoked cert from their ALPN-01 bug in 2022-01")
-			refreshCert = true
 		} else if certPublicKeyAlgoDoesntMatch(tlsSec.Cert, secConf) {
 			log.Printf("Requested key type (UseRSA: %t) doesn't match type of cert in secret %s", secConf.UseRSA, secConf.FullName())
 			refreshCert = true
@@ -505,18 +502,6 @@ func isBlockedRequest(r *http.Request) bool {
 		return !net.ParseIP(r.RemoteAddr[:i]).IsLoopback()
 	}
 	return false
-}
-
-// https://community.letsencrypt.org/t/2022-01-25-issue-with-tls-alpn-01-validation-method/170450
-var letsEncryptFixDeployTime = time.Date(2022, time.January, 26, 00, 48, 0, 0, time.UTC)
-
-// isRevokedLetsEncrypt returns whether the certificate is likely to be part of
-// a batch of certificates revoked by Let's Encrypt in January 2022. This check
-// can be safely removed from May 2022.
-func isRevokedLetsEncrypt(cert *x509.Certificate) bool {
-	O := cert.Issuer.Organization
-	return len(O) == 1 && O[0] == "Let's Encrypt" &&
-		cert.NotBefore.Before(letsEncryptFixDeployTime)
 }
 
 // certPublicKeyAlgoDoesntMatch returns true if the type of key (RSA or ECDSA) used to


### PR DESCRIPTION
`isRevokedLetsEncrypt` was added to force renewal of certificates caught in the [2022-01-25 TLS-ALPN-01 mass revocation](https://community.letsencrypt.org/t/2022-01-25-issue-with-tls-alpn-01-validation-method/170450). The comment on the function said the check could be safely removed from May 2022; it's now four years past that.

Any certificate issued before `2022-01-26 00:48 UTC` would have long since expired (LE certs max out at 90 days) and been refreshed by the existing `closeToExpiration` check, so this branch is dead code.

Removes the function, the `letsEncryptFixDeployTime` package var, and the call site in the renewal loop.