### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,17 +29,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - id: auth
-        uses: google-github-actions/auth@v3.0.0
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           workload_identity_provider: "projects/852340051888/locations/global/workloadIdentityPools/github-deploy/providers/github-deploy"
           service_account: "lekube-deploy@personal-sites-1295.iam.gserviceaccount.com"
           create_credentials_file: true
 
       - id: get-gke-credentials
-        uses: google-github-actions/get-gke-credentials@v3.0.0
+        uses: google-github-actions/get-gke-credentials@3da1e46a907576cefaa90c484278bb5b259dd395 # v3.0.0
         with:
           cluster_name: dg
           location: us-central1-c

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v7
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     - name: Set up Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version-file: ./go.mod
       id: go


### PR DESCRIPTION
Pin all third-party GitHub Actions to full commit SHAs (with version comments) for supply-chain safety.